### PR TITLE
Update crayon_formatter.class.php

### DIFF
--- a/crayon_formatter.class.php
+++ b/crayon_formatter.class.php
@@ -130,9 +130,11 @@ class CrayonFormatter {
                 $info_style .= "min-height: $info_height line-height: $info_height";
             }
         } else if (!$hl->is_inline()) {
-            if (($font_size = CrayonGlobalSettings::get(CrayonSettings::FONT_SIZE)) !== FALSE) {
-                $font_size = $font_size->def() . 'px !important;';
-                $line_height = ($font_size * 1.4) . 'px !important;';
+            $tmp_font_size = CrayonGlobalSettings::get(CrayonSettings::FONT_SIZE);
+            if ($tmp_font_size !== FALSE) {
+                $font_size_def = $tmp_font_size->def();
+                $font_size = $font_size_def . 'px !important;';
+                $line_height = ($font_size_def * 1.4) . 'px !important;';
             }
         }
 


### PR DESCRIPTION
Fix error, "Notice: A non well formed numeric value encountered in crayon-syntax-highlighter/crayon_formatter.class.php on line 134" on PHP 7.1.32, as proposed here: https://github.com/rafaelramalho19/crayon-syntax-highlighter/commit/bb27e77e678511145dc940b1a3629016785a2e99, issue: https://github.com/aramk/crayon-syntax-highlighter/issues/420