### PR TITLE
Invert arguments for implode() in crayon_util.class.php

### DIFF
--- a/util/crayon_util.class.php
+++ b/util/crayon_util.class.php
@@ -70,7 +70,7 @@ class CrayonUtil {
             if ($whitespace) {
                 $delimiter = CRAYON_NL;
             }
-            $lines = implode($lines, $delimiter);
+            $lines = implode($delimiter, $lines);
         }
 
         return $lines;


### PR DESCRIPTION
Historically, PHP's `implode()` method has accepted arguments in either order ("glue, pieces" _or_ "pieces, glue"). However, [the latter form has been deprecated in PHP 7.4](https://www.php.net/manual/en/function.implode.php#refsect1-function.implode-changelog), so running this plugin in a PHP 7.4 environment now produces the following warning:

> Deprecated: implode(): Passing glue string after array is deprecated. Swap the parameters in /path/to/wp-content/plugins/crayon-syntax-highlighter/util/crayon_util.class.php on line 73